### PR TITLE
Expose route as prop on Content view

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ var Router = React.createClass({
           index={route.index}
           toRoute={goForward}
           toBack={goBackwards}
+          route={route}
         />
       </View>
     )


### PR DESCRIPTION
It is nice to be able to pass arbitrary additional properties as part of a route.
React Native's own Navigator provides this via passProps on Navigator routes.
Could at least allow the Content view to examine the route object to get additional sub-props out.
Dunno, this was a point of annoyance in an app.

Could also just implement passProps whole-cloth.