### PR TITLE
Added name property to Custom TitleComponent

### DIFF
--- a/components/NavBarContent.js
+++ b/components/NavBarContent.js
@@ -104,7 +104,7 @@ var NavBarContent = React.createClass({
 
     if (this.props.route.titleComponent) {
       var TitleComponent = this.props.route.titleComponent;
-      titleContent = <TitleComponent />;
+      titleContent = <TitleComponent name={this.props.route.name} />;
     } else {
       titleContent = (
         <Text style={[styles.navbarText, this.props.titleStyle]}>


### PR DESCRIPTION
Passed `name` property to `<TitleComponent />` in case custom Title component needs to be customized using the route name.
