### PR TITLE
Keep hidden nav content item hidden after tween completion

### DIFF
--- a/components/NavBarContent.js
+++ b/components/NavBarContent.js
@@ -23,16 +23,19 @@ var NavBarContent = React.createClass({
   },
 
   componentWillReceiveProps: function(newProps) {
+    var beginOpacity = this.props.willDisappear ? 1 : 0;
+    var endOpacity = this.props.willDisappear ? 0 : 1;
+
     if (newProps.route !== this.props.route) {
       this.setState({
-        opacity: this.props.willDisappear ? 1 : 0
+        opacity: beginOpacity
       });
 
       setTimeout(() => {
         this.tweenState('opacity', {
           easing: tweenState.easingTypes.easeInOutQuad,
           duration: 200,
-          endValue: 1
+          endValue: endOpacity
         });
       }, 0);
     }


### PR DESCRIPTION
When using  `backgroundColor: 'transparent'` on `Router.headerStyle`, after navigating from initial route to a second route, the header content items are displayed one on top of another:
![screen shot 2015-07-06 at 17 10 11](https://cloud.githubusercontent.com/assets/1203949/8526993/f7079456-2401-11e5-9650-3bb0c3943824.png)

This commit fixes the issue by setting the disappearing nav item's opacity tween end value to 0, instead of 1.

Thanks for all the great work on this component, @t4t5!
