### PR TITLE
Use peerDependencies instead of dependencies for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "react-tween-state": "0.0.5"
   },
   "peerDependencies": {
-    "react-native": "^0.4.x"
+    "react-native": ">= 0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "homepage": "https://github.com/t4t5/react-native-router",
   "dependencies": {
-    "react-native": "^0.4.x",
     "react-tween-state": "0.0.5"
+  },
+  "peerDependencies": {
+    "react-native": "^0.4.x"
   }
 }


### PR DESCRIPTION
@t4t5, I am loving the react-native-router.  Had some problems today with react-native 0.6.0 and took a stab at correcting them.  Not sure if this is how you want to go with it but would rather send a PR than just report a problem.

Used approach from here: https://github.com/alinz/react-native-navbar/commit/0d4715e92331086c9c7fda3f041d61199a34b58f

Thanks,

Eric