### PR TITLE
bumped dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "homepage": "https://github.com/t4t5/react-native-router",
   "dependencies": {
-    "react-native": "^0.4.x",
-    "react-tween-state": "0.0.5"
+    "react-native": "^0.8.x",
+    "react-tween-state": "^0.1.x"
   }
 }


### PR DESCRIPTION
## Why
If you had a recent version of react-native, you would get errors when running `npm start`
```
Unable to resolve module ./base64-vlq from /Users/mikaelcarpenter/gears-native/node_modules/react-native-router/node_modules/react-native/Libraries/JavaScriptAppEngine/Initialization/SourceMap.js

{so on and so on}
```

## What
Updated the version numbers in `package.json` dependencies.

This is also an update to a previous PR [(#47)](https://github.com/t4t5/react-native-router/pull/47) by wenkesj

## Issue
[#53](https://github.com/t4t5/react-native-router/issues/53)