### PR TITLE
Don't require old version of react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/t4t5/react-native-router",
   "dependencies": {
-    "react-native": "^0.4.x",
     "react-tween-state": "0.0.5"
   }
 }


### PR DESCRIPTION
This causes errors in newer versions